### PR TITLE
ci: add pull-requests write permission for build comments

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,7 @@ jobs:
       contents: read
       id-token: write
       packages: write
+      pull-requests: write
     steps:
       - uses: vexxhost/docker-atmosphere/.github/actions/build-image@main
         with:


### PR DESCRIPTION
Add `pull-requests: write` permission to enable the build-image action to comment on merged PRs with the image tags and digest.